### PR TITLE
Only use new method to register potentials

### DIFF
--- a/nutmegpotentials/__init__.py
+++ b/nutmegpotentials/__init__.py
@@ -1,8 +1,3 @@
-import openmmml
 from .nutmegpotential import NutmegPotentialImplFactory
 from .util import create_atom_features
-
-openmmml.mlpotential.MLPotential.registerImplFactory('nutmeg-small', NutmegPotentialImplFactory())
-openmmml.mlpotential.MLPotential.registerImplFactory('nutmeg-medium', NutmegPotentialImplFactory())
-openmmml.mlpotential.MLPotential.registerImplFactory('nutmeg-large', NutmegPotentialImplFactory())
 


### PR DESCRIPTION
In OpenMM-ML 1.1, you had to manually register potential functions, typically done in `__init__.py`.  1.2 introduced a new mechanism for automatically discovering potentials.  This library was using both mechanisms to try to work well everywhere, but it turned out that produced an exception on 1.2.  This PR takes out the manual registration and relies entirely on the new mechanism.  That means it requires OpenMM-ML 1.2 or later.