### PR TITLE
NutmegCalculator freezes the model

### DIFF
--- a/nutmegpotentials/nutmegcalculator.py
+++ b/nutmegpotentials/nutmegcalculator.py
@@ -24,7 +24,7 @@ class NutmegCalculator(ase.calculators.calculator.Calculator):
         super().__init__()
         self.implemented_properties: List[str] = ["energy", "forces"]
         self.atoms = atoms
-        model = torch.jit.load(os.path.join(os.path.dirname(__file__), 'models', f'{modelname}.pt'))
+        model = torch.jit.freeze(torch.jit.load(os.path.join(os.path.dirname(__file__), 'models', f'{modelname}.pt')).eval().to(device))
         self.model = model.to(device)
         self.device = device
         from .util import create_atom_features


### PR DESCRIPTION
Freezing the model allows PyTorch to do more optimizations.    In my tests, I get about a 25% speedup from it, which is much larger than the speedup in https://github.com/openmm/openmm-torch/pull/148 for OpenMMTorch.  I believe that's because NutmegCalculator has to disable JIT optimizations to work around a PyTorch bug.  Freezing gives it a chance to do some of those optimizations at an earlier stage.